### PR TITLE
Scan api integrate

### DIFF
--- a/app/javascript/apis/visits.js
+++ b/app/javascript/apis/visits.js
@@ -3,3 +3,9 @@ import Axios from "./axios";
 export const userOngoingVisits = () => Axios.get(`/visits/ongoing`);
 
 export const exitVisit = (id) => Axios.put(`/visits/${id}/exit`);
+
+export const logVisit = (visitableId, visitableType) =>
+  Axios.post(`/visits`, {
+    visitable_type: visitableType,
+    visitable_id: visitableId,
+  });

--- a/app/javascript/components/User/Scan/ComponentByState.js
+++ b/app/javascript/components/User/Scan/ComponentByState.js
@@ -3,6 +3,7 @@ import QrScanner from "./QrScanner";
 import Success from "./Success";
 import Error from "./Error";
 import states from "./states.js";
+import Spinner from "Common/Spinner";
 
 const ComponentByState = ({
   state,
@@ -24,8 +25,10 @@ const ComponentByState = ({
       );
     case states.ERROR_QR_READ:
       return <Error state={state} resetState={resetState} />;
-    case states.ERROR_merchant:
+    case states.ERROR_MERCHANT:
       return <Error state={state} resetState={resetState} />;
+    case states.LOADING:
+      return <Spinner className="w-6 m-auto" />;
   }
 };
 

--- a/app/javascript/components/User/Scan/Error.js
+++ b/app/javascript/components/User/Scan/Error.js
@@ -3,7 +3,7 @@ import Button from "Common/Button";
 import states from "./states.js";
 
 const errorMessages = {
-  [states.ERROR_MERCHANT]: "You are scanning a wrong QR code!.",
+  [states.ERROR_MERCHANT]: "You are scanning a wrong QR code.",
   [states.ERROR_QR_READ]: "Something went wrong while reading QR code.",
 };
 

--- a/app/javascript/components/User/Scan/QrScanner.js
+++ b/app/javascript/components/User/Scan/QrScanner.js
@@ -15,7 +15,7 @@ function QrScanner({ onScanned, onError }) {
   return (
     <div>
       <QrReader
-        delay={300}
+        delay={1000}
         onError={handleError}
         onScan={handleScan}
         style={{ width: "100%" }}

--- a/app/javascript/components/User/Scan/Success.js
+++ b/app/javascript/components/User/Scan/Success.js
@@ -1,18 +1,22 @@
 import React from "react";
-import Button from "Common/Button";
+import { Icon } from "@blueprintjs/core";
 
-function Success({ name, address, resetState }) {
+function Success({ name, address }) {
   return (
     <div>
-      <h2 className="mb-1 text-center text-3xl leading-9 font-extrabold text-gray-900">
+      <div className="flex justify-center">
+        <Icon icon={"tick-circle"} iconSize={44} className="text-green-600" />
+      </div>
+      <p className="mt-2 text-center text-sm leading-5 text-gray-600 max-w">
+        Sucessfully logged your visit
+      </p>
+
+      <h2 className="mb-1 text-center text-xl leading-9 font-extrabold text-gray-900">
         {name}
       </h2>
       <p className="mb-4 text-center text-sm leading-5 text-gray-600 max-w">
         {address}
       </p>
-      <Button colorType="primary" sizeType="lg" block onClick={resetState}>
-        Exit
-      </Button>
     </div>
   );
 }

--- a/app/javascript/components/User/Scan/index.js
+++ b/app/javascript/components/User/Scan/index.js
@@ -1,8 +1,12 @@
 import React, { useState } from "react";
 import states from "./states.js";
 import ComponentByState from "./ComponentByState";
+import { logVisit } from "Apis/visits";
+import Button from "Common/Button";
+import { useHistory } from "react-router-dom";
 
 function Scan() {
+  const history = useHistory();
   const [state, setState] = useState(states.SCANNING);
   const [merchantDetails, setMerchantDetails] = useState({
     name: "",
@@ -13,43 +17,66 @@ function Scan() {
     setState(states.SCANNING);
   };
 
-  const findMerchantDetails = () => {
-    setMerchantDetails({
-      name: "Lulu Hypermarket",
-      address: "Edapally, Kochi",
-    });
-    setState(states.SUCCESS);
-  };
-
   const onScanned = (merchantCode) => {
-    findMerchantDetails(merchantCode);
+    setState(states.LOADING);
+    logVisit(merchantCode, "Merchant")
+      .then((response) => {
+        if (response.data.visitable_id) {
+          setMerchantDetails({
+            name: response.data.name,
+            address: response.data.address,
+          });
+          setState(states.SUCCESS);
+        } else {
+          setState(states.ERROR_MERCHANT);
+        }
+      })
+      .catch(() => {
+        setState(states.ERROR_MERCHANT);
+      });
   };
 
-  const onError = () => {
+  const onErrorScanning = () => {
     setState(states.ERROR_QR_READ);
   };
 
   return (
     <div className="min-h-screen flex flex-col py-12 px-6">
-      <div className="bg-gray-50 flex flex-col justify-center">
+      <div className="flex flex-col justify-center">
         <div className="sm:mx-auto sm:w-full sm:max-w-md">
-          <h2 className="mt-6 text-center text-3xl leading-9 font-extrabold text-gray-900">
-            Scan QR Code
-          </h2>
-          <p className="mt-2 text-center text-sm leading-5 text-gray-600 max-w">
-            Please scan the QR code before entering any shop/establishment.
-          </p>
+          {state != states.SUCCESS && (
+            <>
+              <h2 className="mt-6 text-center text-3xl leading-9 font-extrabold text-gray-900">
+                Scan QR Code
+              </h2>
+              <p className="mt-2 text-center text-sm leading-5 text-gray-600 max-w">
+                Hold your device over a QR Code so that it&apos;s clearly
+                visible within the red box.
+              </p>
+            </>
+          )}
           <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
             <div className="bg-white p-6 shadow sm:rounded-lg sm:px-10">
               <ComponentByState
                 state={state}
                 onScanned={onScanned}
-                onError={onError}
+                onError={onErrorScanning}
                 resetState={resetState}
                 merchantDetails={merchantDetails}
               />
             </div>
           </div>
+          <Button
+            htmlType="button"
+            className="mt-4"
+            block
+            colorType={state === states.SUCCESS && "primary"}
+            onClick={() => {
+              history.push("/user");
+            }}
+          >
+            Go Back
+          </Button>
         </div>
       </div>
     </div>

--- a/app/javascript/components/User/Scan/states.js
+++ b/app/javascript/components/User/Scan/states.js
@@ -3,6 +3,7 @@ const states = {
   ERROR_QR_READ: "ERROR_QR_READ",
   ERROR_MERCHANT: "ERROR_MERCHANT",
   SUCCESS: "SUCCESS",
+  LOADING: "LOADING",
 };
 
 export default states;


### PR DESCRIPTION
Fixes #55

Expecting that `visitable_id` will be saved in QR code.
Using the [logVisit](https://github.com/coronasafe/journal/blob/develop/doc/api.md#log-a-new-visit) api to log the visit. (Arguments, `visitable_id` from the QR scan and visitable_type hardcoded as`Merchant`)

If db contains seed data from develop branch, following example QR code will work as titled.

**Valid QR code**
![qrcode](https://user-images.githubusercontent.com/26934320/87852082-a4d65a80-c91c-11ea-8fdc-88458922923d.png)

**Invalid QR code**
![download](https://user-images.githubusercontent.com/26934320/87852220-bf5d0380-c91d-11ea-90d0-014cde733c56.png)
